### PR TITLE
catch illegal state exceptions

### DIFF
--- a/lib/src/main/java/com/otaliastudios/transcoder/transcode/VideoTrackTranscoder.java
+++ b/lib/src/main/java/com/otaliastudios/transcoder/transcode/VideoTrackTranscoder.java
@@ -154,14 +154,25 @@ public class VideoTrackTranscoder implements TrackTranscoder {
             mEncoderInputSurfaceWrapper = null;
         }
         if (mDecoder != null) {
-            if (mDecoderStarted) mDecoder.stop();
-            mDecoder.release();
-            mDecoder = null;
+            try{
+                if (mDecoderStarted)
+                    mDecoder.stop();
+                mDecoder.release();
+                mDecoder = null;
+            }catch(Exception e){
+                LOG.e("Error stopping decoder. Probably its already released "+e.getMessage());
+            }
         }
         if (mEncoder != null) {
-            if (mEncoderStarted) mEncoder.stop();
-            mEncoder.release();
-            mEncoder = null;
+            try{
+                if (mEncoderStarted)
+                    mEncoder.stop();
+                mEncoder.release();
+                mEncoder = null;
+            }catch(Exception e){
+                LOG.e("Error stopping encoding. Probably its already released "+e.getMessage());
+            }
+
         }
     }
 

--- a/lib/src/main/java/com/otaliastudios/transcoder/transcode/VideoTrackTranscoder.java
+++ b/lib/src/main/java/com/otaliastudios/transcoder/transcode/VideoTrackTranscoder.java
@@ -259,7 +259,12 @@ public class VideoTrackTranscoder implements TrackTranscoder {
 
     private int drainEncoder(long timeoutUs) {
         if (mIsEncoderEOS) return DRAIN_STATE_NONE;
-        int result = mEncoder.dequeueOutputBuffer(mBufferInfo, timeoutUs);
+        int result = MediaCodec.INFO_TRY_AGAIN_LATER;
+        try{
+            result = mEncoder.dequeueOutputBuffer(mBufferInfo, timeoutUs);
+        }catch(Exception e){
+            LOG.e("Error dequeingoutputbuffer ", e);
+        }
         switch (result) {
             case MediaCodec.INFO_TRY_AGAIN_LATER:
                 return DRAIN_STATE_NONE;


### PR DESCRIPTION
 catch any illegalstate exceptions when stopping encoder and decoder. The illegalstate exception is thrown if the encode/decoder has already been released. Otherwise, the uncaught runtime exception (java.lang.Error: Could not shutdown extractor, codecs and muxer pipeline.) prevents compression from completing.