### PR TITLE
Fix Failed to stop the muxer (ref #139)

### DIFF
--- a/lib/src/main/java/com/otaliastudios/transcoder/internal/data/Writer.kt
+++ b/lib/src/main/java/com/otaliastudios/transcoder/internal/data/Writer.kt
@@ -39,14 +39,16 @@ internal class Writer(
     override fun step(state: State.Ok<WriterData>, fresh: Boolean): State<Unit> {
         val (buffer, timestamp, flags) = state.value
         val eos = state is State.Eos
-        info.set(
-                buffer.position(),
-                buffer.remaining(),
-                timestamp,
-                if (eos) {
-                    flags and MediaCodec.BUFFER_FLAG_END_OF_STREAM
-                } else flags
-        )
+        if (eos) {
+            info.set(0, 0, 0, flags and MediaCodec.BUFFER_FLAG_END_OF_STREAM)
+        } else {
+            info.set(
+                    buffer.position(),
+                    buffer.remaining(),
+                    timestamp,
+                    flags
+            )
+        }
         sink.writeTrack(track, buffer, info)
         state.value.release()
         return if (eos) State.Eos(Unit) else State.Ok(Unit)


### PR DESCRIPTION
I think `info.set(0, 0, 0, flags and MediaCodec.BUFFER_FLAG_END_OF_STREAM)` is fine for `EOS`.
Do you think it is correct ?

ref: #139