### PR TITLE
add do not sleep wait state

### DIFF
--- a/lib/src/main/java/com/otaliastudios/transcoder/internal/Segment.kt
+++ b/lib/src/main/java/com/otaliastudios/transcoder/internal/Segment.kt
@@ -24,6 +24,14 @@ internal class Segment(
         return state == null || state !is State.Eos
     }
 
+    fun needsSleep(): Boolean {
+        when(val s = state ?: return false) {
+            is State.Ok -> return false
+            is State.Retry -> return false
+            is State.Wait -> return s.withSleep
+        }
+    }
+
     fun release() {
         pipeline.release()
     }

--- a/lib/src/main/java/com/otaliastudios/transcoder/internal/audio/AudioEngine.kt
+++ b/lib/src/main/java/com/otaliastudios/transcoder/internal/audio/AudioEngine.kt
@@ -64,11 +64,11 @@ internal class AudioEngine(
     override fun drain(): State<EncoderData> {
         if (chunks.isEmpty()) {
             log.i("drain(): no chunks, waiting...")
-            return State.Wait
+            return State.Wait(true)
         }
         val (outBytes, outId) = next.buffer() ?: return run {
             log.i("drain(): no next buffer, waiting...")
-            State.Wait
+            State.Wait(true)
         }
         val outBuffer = outBytes.asShortBuffer()
         return chunks.drain(

--- a/lib/src/main/java/com/otaliastudios/transcoder/internal/codec/Decoder.kt
+++ b/lib/src/main/java/com/otaliastudios/transcoder/internal/codec/Decoder.kt
@@ -92,7 +92,7 @@ internal class Decoder(
         return when (result) {
             INFO_TRY_AGAIN_LATER -> {
                 log.i("drain(): got INFO_TRY_AGAIN_LATER, waiting.")
-                State.Wait
+                State.Wait(true)
             }
             INFO_OUTPUT_FORMAT_CHANGED -> {
                 log.i("drain(): got INFO_OUTPUT_FORMAT_CHANGED, handling format and retrying. format=${codec.outputFormat}")
@@ -117,7 +117,7 @@ internal class Decoder(
                     if (isEos) State.Eos(data) else State.Ok(data)
                 } else {
                     codec.releaseOutputBuffer(result, false)
-                    State.Wait
+                    State.Wait(false)
                 }.also {
                     log.v("drain(): returning $it")
                 }

--- a/lib/src/main/java/com/otaliastudios/transcoder/internal/codec/Encoder.kt
+++ b/lib/src/main/java/com/otaliastudios/transcoder/internal/codec/Encoder.kt
@@ -118,7 +118,7 @@ internal class Encoder(
                     State.Eos(WriterData(buffer, 0L, 0) {})
                 } else {
                     log.i("Can't dequeue output buffer: INFO_TRY_AGAIN_LATER")
-                    State.Wait
+                    State.Wait(true)
                 }
             }
             INFO_OUTPUT_FORMAT_CHANGED -> {

--- a/lib/src/main/java/com/otaliastudios/transcoder/internal/data/Reader.kt
+++ b/lib/src/main/java/com/otaliastudios/transcoder/internal/data/Reader.kt
@@ -28,7 +28,7 @@ internal class Reader(
         val buffer = next.buffer()
         if (buffer == null) {
             log.v("Returning State.Wait because buffer is null.")
-            return State.Wait
+            return State.Wait(true)
         } else {
             return action(buffer.first, buffer.second)
         }
@@ -46,7 +46,7 @@ internal class Reader(
             }
         } else if (!source.canReadTrack(track)) {
             log.i("Returning State.Wait because source can't read $track right now.")
-            State.Wait
+            State.Wait(false)
         } else {
             nextBufferOrWait { byteBuffer, id ->
                 chunk.buffer = byteBuffer

--- a/lib/src/main/java/com/otaliastudios/transcoder/internal/pipeline/State.kt
+++ b/lib/src/main/java/com/otaliastudios/transcoder/internal/pipeline/State.kt
@@ -13,8 +13,8 @@ internal sealed class State<out T> {
     }
 
     // couldn't run, but might in the future
-    object Wait : State<Nothing>() {
-        override fun toString() = "State.Wait"
+    class Wait<T>(val withSleep: Boolean) : State<T>() {
+        override fun toString() = "State.Wait(withSleep: $withSleep)"
     }
 
     // call again as soon as possible

--- a/lib/src/main/java/com/otaliastudios/transcoder/internal/transcode/DefaultTranscodeEngine.kt
+++ b/lib/src/main/java/com/otaliastudios/transcoder/internal/transcode/DefaultTranscodeEngine.kt
@@ -123,7 +123,10 @@ internal class DefaultTranscodeEngine(
             }
 
             if (!advanced) {
-                Thread.sleep(WAIT_MS)
+                val needsSleep = (audio?.needsSleep() ?: false) or (video?.needsSleep() ?: false)
+                if (needsSleep) {
+                    Thread.sleep(WAIT_MS)
+                }
             }
 
             if (++loop % PROGRESS_LOOPS == 0L) {

--- a/lib/src/main/java/com/otaliastudios/transcoder/internal/transcode/DefaultTranscodeEngine.kt
+++ b/lib/src/main/java/com/otaliastudios/transcoder/internal/transcode/DefaultTranscodeEngine.kt
@@ -120,9 +120,13 @@ internal class DefaultTranscodeEngine(
             } else if (completed) {
                 progress(1.0)
                 break
-            } else if (!advanced) {
+            }
+
+            if (!advanced) {
                 Thread.sleep(WAIT_MS)
-            } else if (++loop % PROGRESS_LOOPS == 0L) {
+            }
+
+            if (++loop % PROGRESS_LOOPS == 0L) {
                 val audioProgress = timer.progress.audio
                 val videoProgress = timer.progress.video
                 log.v("transcode(): got progress, video=$videoProgress audio=$audioProgress")

--- a/lib/src/main/java/com/otaliastudios/transcoder/internal/video/VideoRenderer.kt
+++ b/lib/src/main/java/com/otaliastudios/transcoder/internal/video/VideoRenderer.kt
@@ -102,7 +102,7 @@ internal class VideoRenderer(
                 State.Ok(state.value.timeUs)
             } else {
                 state.value.release(false)
-                State.Wait
+                State.Wait(false)
             }
         }
     }


### PR DESCRIPTION
notice: #170 should be merged before merging this PR.

I added `State.wait` which doesn't call sleep. 

There are cases in `State.wait` where it is not necessary to call `Thread.sleep` . 

For example
https://github.com/natario1/Transcoder/blob/main/lib/src/main/java/com/otaliastudios/transcoder/internal/codec/Decoder.kt#L120

Call `Thread.sleep` in `State.wait` slows down the process when trimming the beginning 
Fixes #169

